### PR TITLE
Use case sensitivity when checking reserved words (PHNX-1040)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -48,7 +48,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         importMapping.clear();
 
         supportsInheritance = true;
-        setReservedWordsLowerCase(Arrays.asList(
+        
+        // NOTE: TypeScript uses camel cased reserved words, while models are title cased. We don't want lowercase comparisons.
+        reservedWords.addAll(Arrays.asList(
                 // local variable names used in API methods (endpoints)
                 "varLocalPath", "queryParameters", "headerParams", "formParams", "useFormData", "varLocalDeferred",
                 "requestOptions",
@@ -343,6 +345,12 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             return UNDEFINED_VALUE;
         }
 
+    }
+    
+    @Override
+    protected boolean isReservedWord(String word) {
+        // NOTE: This differs from super's implementation in that TypeScript does _not_ want case insensitive matching.
+        return reservedWords.contains(word);
     }
 
     @Override


### PR DESCRIPTION
Motivation
-------------
Open API generator previously wasn't case sensitive when checking for reserved words in the typescript generator. This will allow us to have the "Package" model in ProductCatalogs without needing to rename anything.

Modifications
------------------
Duplicated the C# logic for reserved words (per the @jimschubert from openapitools' suggestion)

https://centeredge.atlassian.net/browse/PHNX-1040