### PR TITLE
Specify docker image versions (PHNX-9889)

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/Dockerfile.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM alpine:latest AS build
+FROM alpine:2.7 AS build
 
 RUN apk add --update \
         cmake \
@@ -15,7 +15,7 @@ WORKDIR /usr/server/build
 RUN cmake  -DNODEBUG:STRING="ON" ..
 RUN make
 
-FROM alpine:latest AS runtime
+FROM alpine:2.7 AS runtime
 RUN apk add --update \
         libgcc  \
         libstdc++  \

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/Dockerfile
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS build
+FROM alpine:2.7 AS build
 
 RUN apk add --update \
         cmake \
@@ -15,7 +15,7 @@ WORKDIR /usr/server/build
 RUN cmake  -DNODEBUG:STRING="ON" ..
 RUN make
 
-FROM alpine:latest AS runtime
+FROM alpine:2.7 AS runtime
 RUN apk add --update \
         libgcc  \
         libstdc++  \


### PR DESCRIPTION
Motivation
---
When updates are pushed to Docker images with breaking changes and our docker image configuration doesn't specify a version then those breaking changes are pulled into our containers and can break our stuff that was already working just fine

Modification
---
Specify docker image versions

https://centeredge.atlassian.net/browse/PHNX-9889
